### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
     push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
+
+
 name: Run Tests
 permissions:
   contents: read
-
 on:
     push:
         branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/yunji0387/express-auth-server/security/code-scanning/1](https://github.com/yunji0387/express-auth-server/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or job definition in `.github/workflows/test.yml`. Since the workflow only checks out code and runs tests, it likely only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow, just below the `name` field and before the `on` field. This will ensure that all jobs in the workflow inherit these minimal permissions unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
