### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.6.1",
         "ejs": "^3.1.10",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.0.1",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.1",
@@ -2247,6 +2248,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-validator": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
@@ -2400,9 +2418,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -2753,6 +2771,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "mongoose": "^8.16.1",
     "nodemailer": "^6.10.1",
     "passport": "^0.7.0",
-    "passport-google-oauth20": "^2.0.0"
+    "passport-google-oauth20": "^2.0.0",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "jest": "^30.0.2",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,11 +4,20 @@ import { Register, Login, Logout, Verify, GetUser, RequestResetPassword, ResetPa
 import Validate from "../middleware/validate.js";
 import { check } from "express-validator";
 import { VerifyToken } from "../middleware/verify.js";
+import rateLimit from "express-rate-limit";
+
+// Rate limiter for registration: max 5 requests per IP per hour
+const registerLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    message: "Too many accounts created from this IP, please try again after an hour"
+});
 
 const router = express.Router();
 
 router.post(
     "/register",
+    registerLimiter,
     check("email")
         .isEmail()
         .withMessage("Enter a valid email address")


### PR DESCRIPTION
Potential fix for [https://github.com/yunji0387/express-auth-server/security/code-scanning/4](https://github.com/yunji0387/express-auth-server/security/code-scanning/4)

To fix the missing rate limiting on the `/register` route, we should add a rate-limiting middleware to this route. The best way is to use the well-known `express-rate-limit` package, which is specifically designed for this purpose. We will import `express-rate-limit`, configure a rate limiter (e.g., allow a maximum of 5 registration attempts per IP per hour), and apply it as middleware to the `/register` route. This change should be made in `routes/auth.js`, above the route definition. We only need to import the package and add the middleware to the relevant route; no changes to existing functionality are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
