### PR TITLE
Potential fix for code scanning alert no. 12: Database query built from user-controlled sources

### DIFF
--- a/controllers/__tests__/auth/register.test.js
+++ b/controllers/__tests__/auth/register.test.js
@@ -52,7 +52,7 @@ describe('Register Controller', () => {
     await Register(req, res);
 
     // Verify the behavior
-    expect(mockFindOne).toHaveBeenCalledWith({ email: 'john@example.com' });
+    expect(mockFindOne).toHaveBeenCalledWith({ email: { $eq: 'john@example.com' } });
     expect(mockSave).toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
@@ -74,6 +74,7 @@ describe('Register Controller', () => {
     await Register(req, res);
 
     // Verify the behavior
+    expect(mockFindOne).toHaveBeenCalledWith({ email: { $eq: 'john@example.com' } });
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({
       error: {

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -20,7 +20,7 @@ export async function Register(req, res) {
             password,
         });
 
-        const existingUser = await User.findOne({ email });
+        const existingUser = await User.findOne({ email: { $eq: email } });
         if (existingUser) {
             return res.status(400).json({
                 error: {


### PR DESCRIPTION
Potential fix for [https://github.com/yunji0387/express-auth-server/security/code-scanning/12](https://github.com/yunji0387/express-auth-server/security/code-scanning/12)

To fix the issue, we need to ensure that the `email` field is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator in the query. Alternatively, we can validate the `email` field to ensure it is a string before using it in the query. The `$eq` operator is the preferred approach as it directly addresses the injection risk without requiring additional validation logic.

Changes to make:
1. Modify the query on line 23 to use the `$eq` operator for the `email` field.
2. Ensure that the fix does not alter the existing functionality of the `Register` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
