### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -13,6 +13,13 @@ const registerLimiter = rateLimit({
     message: "Too many accounts created from this IP, please try again after an hour"
 });
 
+// Rate limiter for password reset requests: max 5 requests per IP per hour
+const resetPasswordLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    message: "Too many password reset requests from this IP, please try again after an hour"
+});
+
 // Rate limiter for login: max 10 requests per IP per hour
 const loginLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 1 hour
@@ -88,7 +95,7 @@ router.get("/verify", verifyLimiter, VerifyToken, Verify);
 
 router.get("/user", userLimiter, VerifyToken, GetUser);
 
-router.post("/request-reset-password", RequestResetPassword);
+router.post("/request-reset-password", resetPasswordLimiter, RequestResetPassword);
 
 router.post("/reset-password/:token", ResetPassword);
 


### PR DESCRIPTION
Potential fix for [https://github.com/yunji0387/express-auth-server/security/code-scanning/9](https://github.com/yunji0387/express-auth-server/security/code-scanning/9)

To fix the missing rate limiting on the `/request-reset-password` endpoint, we should add a rate limiter middleware to this route, similar to how it's done for `/register` and `/login`. The best approach is to define a new rate limiter instance (e.g., `resetPasswordLimiter`) with appropriate settings (e.g., limit to 5 requests per hour per IP), and apply it to the `/request-reset-password` route. This change should be made in `routes/auth.js`, by:

- Defining a new rate limiter instance near the other limiter definitions.
- Applying the limiter as middleware to the `/request-reset-password` route (line 91).

No changes to existing functionality are required; just the addition of the rate limiter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
