### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -32,7 +32,17 @@ app.get("/", (req, res) => {
 });
 
 app.get("/reset-password/:token", (req, res) => {
-    res.render("reset-password", { token: req.params.token });
+    // Only allow tokens that match a strict pattern (e.g., JWT: base64url segments, or UUID)
+    const token = req.params.token;
+    // Example: JWT regex (three base64url segments separated by dots)
+    const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/;
+    // Example: UUID regex (v4)
+    const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+    if (jwtRegex.test(token) || uuidRegex.test(token)) {
+        res.render("reset-password", { token });
+    } else {
+        res.status(400).send("Invalid or malformed token.");
+    }
 });
 
 export default app;


### PR DESCRIPTION
Potential fix for [https://github.com/yunji0387/express-auth-server/security/code-scanning/3](https://github.com/yunji0387/express-auth-server/security/code-scanning/3)

To fix the SSRF risk, we should ensure that the `token` parameter is strictly validated server-side before it is passed to the template and used in the AJAX request. The best way is to check that the token matches the expected format (e.g., a UUID, JWT, or a specific regex) in the route handler in `routes/index.js`. If the token is invalid, return an error or a safe page instead of rendering the template. This prevents malicious input from reaching the client and being used in the request URL.

**Steps:**
- In `routes/index.js`, update the `/reset-password/:token` route to validate `req.params.token` using a regex (e.g., only allow alphanumeric and dashes, or match a UUID/JWT format).
- If the token is invalid, respond with a 400 error or render an error page.
- No changes are needed in `views/reset-password.ejs` if the server-side validation is strict.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
